### PR TITLE
Added a failsafe for do_delete

### DIFF
--- a/unmerged-cleaner/ListDeletable.py
+++ b/unmerged-cleaner/ListDeletable.py
@@ -372,6 +372,14 @@ def do_delete():
         for deleted in deletions.readlines():
             deleting = lfn_to_pfn(deleted.strip('\n'))
 
+            # Do a check of the directory names. End process if something is wrong.
+            if '/unmerged/' not in deleting:
+                print 'Something is either wrong with your deletions file or'
+                print 'ListDetetable.do_delete().'
+                print 'Your deletions file is at', config.DELETION_FILE
+                print 'Refusing to continue.'
+                exit()
+
             if config.STORAGE_TYPE == 'Hadoop':
                 # Hadoop stores also a directory with checksums
                 hadoop_delete(deleting.replace('/mnt/hadoop', '/mnt/hadoop/cksums'))


### PR DESCRIPTION
The do_delete function now refuses to delete any path that does not have '/unmerged/' in it and calls a system exit.