### PR TITLE
Check config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,16 +153,5 @@ The unmerged cleaner also makes use of the local module defined in ``ConfigTools
 .. automodule:: ConfigTools
    :members:
 
-SiteAdminToolkit Forks' Build Statuses
---------------------------------------
-
-If you have a fork with automated build tests set up
-(see :ref:`tests-ref`), then feel free to add your badge here for easy viewing.
-
-dabercro: |build-dabercro|
-
-.. |build-dabercro| image:: https://travis-ci.org/dabercro/SiteAdminToolkit.svg?branch=master
-    :target: https://travis-ci.org/dabercro/SiteAdminToolkit
-
 .. |build| image:: https://travis-ci.org/CMSCompOps/SiteAdminToolkit.svg?branch=master
     :target: https://travis-ci.org/CMSCompOps/SiteAdminToolkit

--- a/test/config.py
+++ b/test/config.py
@@ -16,7 +16,7 @@ if len(sys.argv) > 1:
     UNMERGED_DIR_LOCATION = os.path.abspath(sys.argv.pop(1))
 else:
     UNMERGED_DIR_LOCATION = os.path.join(
-        os.path.abspath(os.path.dirname(__file__)), 'unmerged')
+        os.path.abspath(os.path.dirname(__file__)), 'store/unmerged')
 
 if len(sys.argv) == 1:
     sys.argv.append('posix')

--- a/test/test_unmerged_cleaner.py
+++ b/test/test_unmerged_cleaner.py
@@ -215,12 +215,12 @@ class TestUnmergedFileChecks(unittest.TestCase):
         self.assertTrue(os.path.exists(self.tmpdir.getpath('dir')))
 
 
-class TestStartingConditions(unittest.TestCase):
+class TestConditions(unittest.TestCase):
 
     def test_no_protected(self):
         protected = ListDeletable.PROTECTED_LIST
         ListDeletable.PROTECTED_LIST = []
-        self.assertRaises(ListDeletable.SuspiciousStartingConditions, ListDeletable.main)
+        self.assertRaises(ListDeletable.SuspiciousConditions, ListDeletable.main)
 
         ListDeletable.PROTECTED_LIST = protected
 
@@ -233,9 +233,14 @@ class TestStartingConditions(unittest.TestCase):
 
         self.assertFalse(ListDeletable.config.UNMERGED_DIR_LOCATION.endswith('/store/unmerged'))
 
-        self.assertRaises(ListDeletable.SuspiciousStartingConditions, ListDeletable.main)
+        self.assertRaises(ListDeletable.SuspiciousConditions, ListDeletable.main)
 
         ListDeletable.config.UNMERGED_DIR_LOCATION = unmerged
+
+    def test_bad_file_start(self):
+        self.assertRaises(ListDeletable.SuspiciousConditions, ListDeletable.filter_protected,
+                          [os.path.join(ListDeletable.config.UNMERGED_DIR_LOCATION.replace('/store/', '/disk/store/'),
+                                        'example/file/location.root')], [])
 
 
 if __name__ == '__main__':

--- a/test/test_unmerged_cleaner.py
+++ b/test/test_unmerged_cleaner.py
@@ -242,6 +242,11 @@ class TestConditions(unittest.TestCase):
                           [os.path.join(ListDeletable.config.UNMERGED_DIR_LOCATION.replace('/store/', '/disk/store/'),
                                         'example/file/location.root')], [])
 
+    def test_partial_match(self):
+        self.assertRaises(ListDeletable.SuspiciousConditions, ListDeletable.filter_protected,
+                          [os.path.join(ListDeletable.config.UNMERGED_DIR_LOCATION, 'store/unmerged/protected/file.root')],
+                          ['/store/unmerged/protected/file.root'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_unmerged_cleaner.py
+++ b/test/test_unmerged_cleaner.py
@@ -220,8 +220,7 @@ class TestStartingConditions(unittest.TestCase):
     def test_no_protected(self):
         protected = ListDeletable.PROTECTED_LIST
         ListDeletable.PROTECTED_LIST = []
-        with self.assertRaises(ListDeletable.SuspiciousStartingConditions):
-            ListDeletable.main()
+        self.assertRaises(ListDeletable.SuspiciousStartingConditions, ListDeletable.main)
 
         ListDeletable.PROTECTED_LIST = protected
 
@@ -234,8 +233,7 @@ class TestStartingConditions(unittest.TestCase):
 
         self.assertFalse(ListDeletable.config.UNMERGED_DIR_LOCATION.endswith('/store/unmerged'))
 
-        with self.assertRaises(ListDeletable.SuspiciousStartingConditions):
-            ListDeletable.main()
+        self.assertRaises(ListDeletable.SuspiciousStartingConditions, ListDeletable.main)
 
         ListDeletable.config.UNMERGED_DIR_LOCATION = unmerged
 

--- a/test/test_unmerged_cleaner.py
+++ b/test/test_unmerged_cleaner.py
@@ -215,5 +215,30 @@ class TestUnmergedFileChecks(unittest.TestCase):
         self.assertTrue(os.path.exists(self.tmpdir.getpath('dir')))
 
 
+class TestStartingConditions(unittest.TestCase):
+
+    def test_no_protected(self):
+        protected = ListDeletable.PROTECTED_LIST
+        ListDeletable.PROTECTED_LIST = []
+        with self.assertRaises(ListDeletable.SuspiciousStartingConditions):
+            ListDeletable.main()
+
+        ListDeletable.PROTECTED_LIST = protected
+
+    def test_no_unmerged_pfn(self):
+        self.assertTrue(ListDeletable.config.UNMERGED_DIR_LOCATION.endswith('/store/unmerged'))
+
+        unmerged = ListDeletable.config.UNMERGED_DIR_LOCATION
+        ListDeletable.config.UNMERGED_DIR_LOCATION = '/'.join(
+            ListDeletable.config.UNMERGED_DIR_LOCATION.split('/')[:-2])
+
+        self.assertFalse(ListDeletable.config.UNMERGED_DIR_LOCATION.endswith('/store/unmerged'))
+
+        with self.assertRaises(ListDeletable.SuspiciousStartingConditions):
+            ListDeletable.main()
+
+        ListDeletable.config.UNMERGED_DIR_LOCATION = unmerged
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/unmerged-cleaner/ListDeletable.py
+++ b/unmerged-cleaner/ListDeletable.py
@@ -107,7 +107,7 @@ except ImportError:
     exit()
 
 
-class SuspiciousStartingConditions(Exception):
+class SuspiciousConditions(Exception):
     """
     An exception for catching anticipated configuration an tool problems.
     """
@@ -479,6 +479,8 @@ def filter_protected(unmerged_files, protected):
 
     :param list unmerged_files: the list of files to check and delete, if unprotected.
     :param list protected: the list of protected LFNs.
+    :raises SuspiciousConditions: If the beginning of the file name does not match the
+                                  configured location of ``/store/unmerged``
     """
 
     print 'Got %i deletion candidates' % len(unmerged_files)
@@ -491,6 +493,11 @@ def filter_protected(unmerged_files, protected):
 
         for unmerged_file in unmerged_files:
             protect = False
+
+            if not unmerged_file.startswith(config.UNMERGED_DIR_LOCATION):
+                raise SuspiciousConditions(
+                    '\nFile %s\nis not in your configured unmerged location:\n%s' %
+                    (unmerged_file, config.UNMERGED_DIR_LOCATION))
 
             for lfn in protected:
                 pfn = lfn_to_pfn(lfn)
@@ -520,7 +527,7 @@ def main():
 
     # Perform some checks of configuration file
     if not config.UNMERGED_DIR_LOCATION.endswith('/store/unmerged'):
-        raise SuspiciousStartingConditions(
+        raise SuspiciousConditions(
             '\n\'/store/unmerged\' not at the end of your PFN path: %s\n'
             'This tool replaces the \'/store/unmerged\' part of the LFN with your PFN path.\n'
             '(So it will expect \'/store/unmerged/protected/dir\' at \'%s\')\n'
@@ -529,7 +536,7 @@ def main():
 
     # Expect protected LFN list from Unified
     if not PROTECTED_LIST:
-        raise SuspiciousStartingConditions(
+        raise SuspiciousConditions(
             '\nNo directories are protected.\n'
             'Check https://cmst2.web.cern.ch/cmst2/unified/listProtectedLFN.txt')
 

--- a/unmerged-cleaner/ListDeletable.py
+++ b/unmerged-cleaner/ListDeletable.py
@@ -523,7 +523,8 @@ def main():
         raise SuspiciousStartingConditions(
             '\n\'/store/unmerged\' not at the end of your PFN path: %s\n'
             'This tool replaces the \'/store/unmerged\' part of the LFN with your PFN path.\n'
-            '(So it will expect \'/store/unmerged/protected/dir\' at \'%s\')'
+            '(So it will expect \'/store/unmerged/protected/dir\' at \'%s\')\n'
+            'If that is intended, please modify the beginning of this script\'s main() function.'
             % (config.UNMERGED_DIR_LOCATION, lfn_to_pfn('/store/unmerged/protected/dir')))
 
     # Expect protected LFN list from Unified

--- a/unmerged-cleaner/ListDeletable.py
+++ b/unmerged-cleaner/ListDeletable.py
@@ -501,7 +501,7 @@ def filter_protected(unmerged_files, protected):
 
         for lfn in protected:
             pfn = lfn_to_pfn(lfn)
-            if unmerged_file.startswith(pfn):
+            if pfn in unmerged_file:
                 protect = True
                 break
             elif lfn in unmerged_file:

--- a/unmerged-cleaner/ListDeletable.py
+++ b/unmerged-cleaner/ListDeletable.py
@@ -481,6 +481,7 @@ def filter_protected(unmerged_files, protected):
     :param list protected: the list of protected LFNs.
     :raises SuspiciousConditions: If the beginning of the file name does not match the
                                   configured location of ``/store/unmerged``
+                                  or if there is a partial match with a protected LFN
     """
 
     print 'Got %i deletion candidates' % len(unmerged_files)
@@ -500,9 +501,15 @@ def filter_protected(unmerged_files, protected):
 
         for lfn in protected:
             pfn = lfn_to_pfn(lfn)
-            if pfn in unmerged_file:
+            if unmerged_file.startswith(pfn):
                 protect = True
                 break
+            elif lfn in unmerged_file:
+                raise SuspiciousConditions(
+                    '\nFile %s\nhas partial match to LFN %s,\n'
+                    'but LFN mapped to %s\nCheck your configuration file' %
+                    (unmerged_file, lfn, pfn))
+
 
         for root_dir in config.DIRS_TO_AVOID:
             pfn = os.path.join(config.UNMERGED_DIR_LOCATION, root_dir)


### PR DESCRIPTION
Check the configuration for the following:
- Matches beginning of file names (In case filter is not actually doing the listing)
- PFN ends with `/store/unmerged` (with instructions on where to remove check, if needed)
- Protected directories are not an empty list (in case something goes wrong with list generation)